### PR TITLE
Uniswap v3 migration (swap tokens)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,9 @@ jobs:
           forge build --sizes
         id: build
 
-      - name: Run Forge tests
+      - name: Run tests with fork URL
+        env:
+          FORK_URL: ${{secrets.FORK_URL}}
         run: |
-          forge test -vvv
+          forge test --fork-url $FORK_URL
         id: test

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/v3-periphery"]
+	path = lib/v3-periphery
+	url = https://github.com/Uniswap/v3-periphery

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Liquidity Pool Connector
+# 🔌 Liquidity Pool Connector
 
-This project is designed to facilitate token swaps and manage liquidity in a Uniswap V2-compatible decentralized exchange. It is optimized for usage on networks like Arbitrum.
+This project is designed to facilitate token swaps and manage liquidity in a Uniswap V2-compatible decentralized exchange. It is optimized for usage on networks like Arbitrum (migration to Uniswap V3 in progress 📈).
 
 ## 📜 Overview
 
@@ -77,7 +77,7 @@ forge coverage --fork-url https://arb1.arbitrum.io/rpc
 
 Here are some possible improvements and extensions for the Liquidity Pool Connector:
 
-### 🔄 Upgrade to Uniswap V4
+### 🔄 Upgrade to Uniswap V4 (migration to v3 in progress since v4 is still under development)
 
 - **Migration to Uniswap V4 architecture** to benefit from:
   - Singleton contract design (reduced gas costs)

--- a/src/interfaces/IV3SwapRouter.sol
+++ b/src/interfaces/IV3SwapRouter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IV3SwapRouter {
+    struct ExactInputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+    }
+
+    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+}

--- a/test/SwapAppTest.t.sol
+++ b/test/SwapAppTest.t.sol
@@ -115,7 +115,6 @@ contract SwapAppTest is Test {
         assertApproxEqAbs(amountA, expectedA, toleranceA, "amountA out of range");
         assertApproxEqAbs(amountB, expectedB, toleranceB, "amountB out of range");
 
-
         vm.stopPrank();
     }
 }

--- a/test/SwapAppTest.t.sol
+++ b/test/SwapAppTest.t.sol
@@ -9,15 +9,17 @@ import "../src/SwapApp.sol";
 contract SwapAppTest is Test {
     SwapApp app;
 
-    address uniswapV2SwapRouterAddress = 0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24;
-    address uniswapV2SwapFactoryAddress = 0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9;
-    address user = 0xB45323118e29e3C33c4a906dD8ce9d9CF443D380; // Address with USDT on Arbitrum Mainnet
-    address USDT = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9;
-    address DAI = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
+    address public constant uniswapV2SwapRouterAddress = 0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24;
+    address public constant uniswapV3SwapRouterAddress = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address public constant uniswapV2SwapFactoryAddress = 0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9;
+    address public constant user = 0xB45323118e29e3C33c4a906dD8ce9d9CF443D380; // Address with USDT on Arbitrum Mainnet
+    address public constant USDT = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9;
+    address public constant DAI = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
 
     /// @notice Deploys the SwapApp contract before each test using a forked network
     function setUp() public {
-        app = new SwapApp(uniswapV2SwapRouterAddress, uniswapV2SwapFactoryAddress, USDT, DAI);
+        app =
+            new SwapApp(uniswapV2SwapRouterAddress, uniswapV3SwapRouterAddress, uniswapV2SwapFactoryAddress, USDT, DAI);
     }
 
     /// @notice Verifies that the contract is deployed with the correct router address
@@ -116,5 +118,51 @@ contract SwapAppTest is Test {
         assertApproxEqAbs(amountB, expectedB, toleranceB, "amountB out of range");
 
         vm.stopPrank();
+    }
+
+    /// @notice Tests a successful token swap on Uniswap V3 from USDT to DAI
+    function testSwapTokensV3HappyPath() public {
+        deal(USDT, user, 100 * 1e6);
+        uint256 amountIn_ = 100e6; // 100 USDT
+        uint256 amountOutMin_ = 1e18; // 1 DAI minimum
+        uint256 deadline_ = block.timestamp + 1 hours;
+
+        address[] memory path_ = new address[](2);
+        path_[0] = USDT;
+        path_[1] = DAI;
+
+        // Approve the contract to spend user's tokens
+        vm.prank(user);
+        IERC20(USDT).approve(address(app), amountIn_);
+
+        // Execute swap
+        vm.prank(user);
+        uint256 amountOut = app.swapTokensV3(amountIn_, amountOutMin_, path_, user, deadline_);
+
+        console.log("AmountOut:", amountOut);
+
+        // Validate user balance is greater than or equal to amountOutMin_
+        uint256 daiBalance = IERC20(DAI).balanceOf(user);
+        assertGe(daiBalance, amountOutMin_, "DAI balance too low");
+    }
+
+    /// @notice Tests that `swapTokensV3` reverts if the swap path is too short
+    function testSwapTokensV3ShouldRevertIfPathIsTooShort() public {
+        deal(USDT, user, 100 * 1e6);
+        uint256 amountIn_ = 100e6; // 100 USDT
+        uint256 amountOutMin_ = 1e18; // 1 DAI minimum
+        uint256 deadline_ = block.timestamp + 1 hours;
+
+        // Make a too short path so that the tx reverts
+        address[] memory path_ = new address[](1);
+        path_[0] = USDT;
+
+        // Approve the contract to spend user's tokens
+        vm.prank(user);
+        IERC20(USDT).approve(address(app), amountIn_);
+
+        // Execute swap with a too short path
+        vm.expectRevert("Path too short");
+        app.swapTokensV3(amountIn_, amountOutMin_, path_, user, deadline_);
     }
 }


### PR DESCRIPTION
### Implement `swapTokensV3` with Uniswap V3 Support

#### ✅ Changes Introduced:
- Added the `swapTokensV3` function to support token swaps using Uniswap V3, including multihop swaps with encoded paths.
- Implemented the internal `_encodePath` function with a fixed 0.3% fee tier (`3000`) between hops.
- Added test coverage for `swapTokensV3`:
  - `testSwapTokensV3HappyPath`: validates a successful USDT → DAI swap.
  - `testSwapTokensV3ShouldRevertIfPathIsTooShort`: verifies that the function reverts when the path length is insufficient.
- Completed and improved NatSpec documentation for all public functions.

#### 🧪 Testing:
- All tests pass using a mainnet fork.
- Test suite covers both happy paths and expected revert conditions.

#### 🛠 Requirements:
- Ensure a valid fork RPC URL (e.g., Arbitrum) is available and set as `FORK_URL` in GitHub Actions or your local environment.
